### PR TITLE
Fix typo in error var name

### DIFF
--- a/bin/commands/distil.js
+++ b/bin/commands/distil.js
@@ -152,7 +152,7 @@ function compile (filename, callback) {
 	exec('luac -o ' + luacFilename + ' ' + filename, function (err, stdout, stderr) {
 		if (err) {
 			errPart = err.message.split(/:\s?/);
-			if (errPart[1] != 'luac') throw e;
+			if (errPart[1] != 'luac') throw err;
 			
 			console.error(COLORS.RED + 'Luac compile error in file ' + errPart[2] + ' on line ' + errPart[3] + ':\n\t' + errPart[4] + COLORS.RESET);
 			return;


### PR DESCRIPTION
`e` → `err`
