### PR TITLE
string.match -- allow matches of square brackets as magic characters

### DIFF
--- a/test/scripts/lib-string.lua
+++ b/test/scripts/lib-string.lua
@@ -508,7 +508,15 @@ local c = string.lower (a);
 assertTrue (b == '', 'string.lower() should return an empty string if passed an empty string')
 assertTrue (c == 'mclaren mercedes', 'string.lower() should return the string in the first argument with all character in lower case')
 
+-- match
 
+local a = '[4,8]'
+
+local b = string.match(a,'[%[]');
+local c = string.match(a,'%[');
+
+assertTrue(b == '[', 'string.match() should return the magic character when we search for it as part of a group.')
+assertTrue(c == '[', 'string.match() should return the magic character when we search for it outside of a group.')
 
 
 -- rep

--- a/vm/src/lib.js
+++ b/vm/src/lib.js
@@ -153,31 +153,9 @@
 		// TODO Add support for balanced character matching (not sure this is easily achieveable).
 		pattern = '' + pattern;
 
-		var n = 0,
-			i, l, character, addSlash;
+		var i;
 					
 		for (i in ROSETTA_STONE) if (ROSETTA_STONE.hasOwnProperty(i)) pattern = pattern.replace(new RegExp(i, 'g'), ROSETTA_STONE[i]);
-		l = pattern.length;
-
-		for (i = 0; i < l; i++) {
-			character = pattern.substr(i, 1);
-			addSlash = false;
-
-			if (character == '[') {
-				if (n) addSlash = true;
-				n++;
-
-			} else if (character == ']') {
-				n--;
-				if (n) addSlash = true;
-			}
-
-			if (addSlash) {
-				// pattern = pattern.substr(0, i) + '\\' + pattern.substr(i++);
-				pattern = pattern.substr(0, i) + pattern.substr(i++ + 1);
-				l++;
-			}
-		}			
 
 		return pattern;	
 	}


### PR DESCRIPTION
Removed some problematic code that was preventing matching of square brackets as magic characters.
