### PR TITLE
DumpSizeT should not always dump an 8 byte integer

### DIFF
--- a/extensions/luac/yueliang.lua
+++ b/extensions/luac/yueliang.lua
@@ -1329,7 +1329,9 @@ do
 	------------------------------------------------------------------------
 	function luaU:DumpSizeT(x, D)
 		self:DumpBlock(self:from_int(x), D)
-		self:DumpBlock(self:from_int(0), D)
+		if size_size_t == 8 then
+			self:DumpBlock(self:from_int(0), D)
+		end
 	end
 
 	------------------------------------------------------------------------


### PR DESCRIPTION
If `size_size_t` is 4, only 4 bytes should be dumped.
