### PR TITLE
Update unlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 */.svn/*
 */*/.svn/*
 node_modules/
+package-lock.json
 
 .DS_Store

--- a/bin/commands/distil.js
+++ b/bin/commands/distil.js
@@ -111,7 +111,7 @@ function parseCommand (args) {
 		for (i = 0, l = files.length; i < l; i++) {
 			outstanding++;
 
-			distilFile(files[i][0], files[i][1], args.switches, function () { 
+			distilFile(files[i][0], files[i][1], args.switches, function () {
 				if (!--outstanding) success();
 			});
 
@@ -161,13 +161,13 @@ function compile (filename, switches, callback) {
 		if (err) {
 			errPart = err.message.split(/:\s?/);
 			if (errPart[1] != 'luac') throw err;
-			
+
 			console.error(COLORS.RED + 'Luac compile error in file ' + errPart[2] + ' on line ' + errPart[3] + ':\n\t' + errPart[4] + COLORS.RESET);
 			return;
 		}
 
 		callback(fs.readFileSync(luacFilename, 'binary').toString());
-		fs.unlink(luacFilename);
+		fs.unlinkSync(luacFilename);
 	});
 }
 
@@ -176,7 +176,7 @@ function compile (filename, switches, callback) {
 
 function distil (source, switches, callback) {
 	compile(source, switches, function (bytecode) {
-		
+
 		var parser = new Parser(),
 			config = {
 				stripDebugging: switches.stripDebugging,

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"url": "https://github.com/gamesys/moonshine/issues"
 	},
 	"dependencies": {
-		"express": "3.2.5",
-		"socket.io": "0.9.14"
+		"express": "^3.21.2",
+		"socket.io": "^4.1.2"
 	}
 }

--- a/vm/build/build
+++ b/vm/build/build
@@ -34,7 +34,7 @@
  *
  * Note: Requires Google Closure Compiler to be installed in /usr/local/bin
  *       https://developers.google.com/closure/compiler/
- * 
+ *
  * Examples:
  * 	./build				Builds JavaScript lib files.
  * 	./build -swc 		Builds JavaScript and ActionScript lib files.
@@ -66,7 +66,7 @@ var switches = getSwitches(process.argv),
 		'../src/jit.js',
 		'../src/lib.js',
 		'../src/utils.js',
-		'../src/output.js'		
+		'../src/output.js'
 	],
 	OUTPUT_FILENAME = '../moonshine.js',
 	HEADER_FILENAME = './header.js',
@@ -165,7 +165,7 @@ function minifyLibrary () {
 		appendFile(output, filename);
 
 		fs.closeSync(output);
-		fs.unlink(filename);
+		fs.unlinkSync(filename);
 
 		console.log('File written: ' + MINIFIED_OUTPUT_FILENAME);
 		if (switches['-module']) buildModule();
@@ -190,7 +190,7 @@ function buildSWC () {
 
 	exec(cmd, function (err) {
 		if (err) throw err;
-		fs.unlink(filename);
+		fs.unlinkSync(filename);
 
 		console.log('File written: ' + SWC_OUTPUT_FILENAME);
 	});
@@ -210,8 +210,7 @@ function buildModule () {
 	fs.writeSync(output, 'define(function(require,exports,module){\n');
 	appendFile(output, MINIFIED_OUTPUT_FILENAME);
 	fs.writeSync(output, '\n});');
-	
+
 	fs.closeSync(output);
 	console.log('File written: ' + MODULE_FILENAME);
 }
-


### PR DESCRIPTION
Hello!

Thanks a lot for Moonshine - what a marvelous work!

However, nowadays, the distiller will not work any longer as Node.js now strictly requires a callback as the second argument of "fs.unlink" - or (what might be safer) requires using "fs.unlinkSync" instead.

This is why I (among other minor changes) simply changed the broken calls in your code - now, I am able to distill Lua scripts again.

Perhaps, they may be of some use for you.

With greetings from Germany,

Andreas Rozek